### PR TITLE
test: Fix test cases and linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   "devDependencies": {
     "bootprint": "^1.0.0",
     "chai": "^3.5.0",
+    "dirty-chai": "^2.0.1",
     "ghooks": "^2.0.0",
-    "m-io": "^0.5.0",
+    "m-io": "0.4.0",
     "mocha": "^3.2.0",
     "thoughtful-release": "^0.3.0",
     "trace-and-clarify-if-possible": "^1.0.0"

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -9,7 +9,9 @@
 /* global it */
 /* global before */
 
-var expect = require('chai').expect
+var chai = require('chai')
+chai.use(require('dirty-chai'))
+var expect = chai.expect
 var path = require('path')
 var qfs = require('m-io/fs')
 var fs = require('fs')
@@ -28,7 +30,7 @@ function outputFile (filename) {
 }
 
 describe('The bootprint-base module', function () {
-  this.timeout(10000)
+  this.timeout(20000)
 
   it('should include the bootstrap javascript in the output', function () {
     return require('bootprint')
@@ -53,7 +55,7 @@ describe('The bootprint-base module', function () {
 
               var jqueryIndex = bundle.indexOf('jQuery requires a window with a document')
               var bootstrapIndex = bundle.indexOf("Bootstrap's JavaScript requires jQuery")
-              expect(jqueryIndex < bootstrapIndex, 'jQuery must be included before Bootstrap').to.be.true
+              expect(jqueryIndex < bootstrapIndex, 'jQuery must be included before Bootstrap').to.be.true()
             })
   })
 })


### PR DESCRIPTION
- m-io@0.5.0 does not work with node 0.10 and 0.12
- recent versions of standardjs don't allow chai-expressions like
  "expect(ab).to.be.true", so dirty-chai is now used here.
- extend timeout (for node 0.12)